### PR TITLE
Signed distance for closestBed

### DIFF
--- a/src/closestBed/closestBed.h
+++ b/src/closestBed/closestBed.h
@@ -29,7 +29,8 @@ public:
     // constructor
     BedClosest(string &bedAFile, string &bedBFile, 
                bool sameStrand, bool diffStrand, string &tieMode, 
-               bool reportDistance, bool signDistance, bool ignoreOverlaps);
+               bool reportDistance, bool signDistance, string &strandedDistMode,
+               bool ignoreOverlaps);
 
     // destructor
     ~BedClosest(void);
@@ -47,6 +48,7 @@ private:
     bool   _diffStrand;
     bool   _reportDistance;
     bool   _signDistance;
+    string _strandedDistMode;
     bool   _ignoreOverlaps;
 
     BedFile *_bedA, *_bedB;

--- a/src/closestBed/closestMain.cpp
+++ b/src/closestBed/closestMain.cpp
@@ -32,6 +32,7 @@ int main(int argc, char* argv[]) {
     string bedAFile;
     string bedBFile;
     string tieMode = "all";
+    string strandedDistMode = "ref";
 
     bool haveBedA       = false;
     bool haveBedB       = false;
@@ -41,6 +42,7 @@ int main(int argc, char* argv[]) {
     bool ignoreOverlaps = false;
     bool reportDistance = false;
     bool signDistance   = false;
+    bool haveStrandedDistMode = false;
 
 
     // check to see if we should print out some help
@@ -86,8 +88,13 @@ int main(int argc, char* argv[]) {
             reportDistance = true;
         }
         else if (PARAMETER_CHECK("-D", 2, parameterLength)) {
-            reportDistance = true;
-            signDistance = true;
+            if ((i+1) < argc) {
+                reportDistance = true;
+                signDistance = true;
+                haveStrandedDistMode = true;
+                strandedDistMode = argv[i + 1];
+                i++;
+            }
         }
         else if (PARAMETER_CHECK("-io", 3, parameterLength)) {
             ignoreOverlaps = true;
@@ -116,6 +123,12 @@ int main(int argc, char* argv[]) {
         cerr << endl << "*****" << endl << "*****ERROR: Request \"all\" or \"first\" or \"last\" for Tie Mode (-t)" << endl << "*****" << endl;
         showHelp = true;
     }
+    
+    if (haveStrandedDistMode && (strandedDistMode != "a") && (strandedDistMode != "b")
+                             && (strandedDistMode != "ref")) {
+        cerr << endl << "*****" << endl << "*****ERROR: Request \"a\" or \"b\" or \"ref\" for Stranded Distance Mode (-D)" << endl << "*****" << endl;
+        showHelp = true;
+    }
 
     if (sameStrand && diffStrand) {
         cerr << endl << "*****" << endl << "*****ERROR: Request either -s OR -S, not both." << endl << "*****" << endl;
@@ -123,7 +136,7 @@ int main(int argc, char* argv[]) {
     }
     
     if (!showHelp) {
-        BedClosest *bc = new BedClosest(bedAFile, bedBFile, sameStrand, diffStrand, tieMode, reportDistance, signDistance, ignoreOverlaps);
+        BedClosest *bc = new BedClosest(bedAFile, bedBFile, sameStrand, diffStrand, tieMode, reportDistance, signDistance, strandedDistMode, ignoreOverlaps);
         delete bc;
         return 0;
     }
@@ -159,8 +172,14 @@ void ShowHelp(void) {
     
     cerr << "\t-D\t"            << "Like -d, report the closest feature in B, and its distance to A" << endl;
     cerr                        << "\t\tas an extra column. Unlike -d, use negative distances to report" << endl;
-    cerr                        << "\t\tif feature B is upstream of A. Note: Upstream B features are" << endl;
-    cerr                        << "\"to the right\" of features on the - strand" << endl << endl;
+    cerr                        << "\t\tupstream features. You must specify which orientation defines \"upstream\"." << endl;
+    cerr                        << "\t\tThe options are:" << endl;
+    cerr                        << "\t\t- \"ref\"   Report distance with respect to the reference genome. " << endl;
+    cerr                        << "\t\t            B features with a lower (start, stop) are upstream" << endl;
+    cerr                        << "\t\t- \"a\"     Report distance with respect to A." << endl;
+    cerr                        << "\t\t            When A is on the - strand, \"upstream\" means B has a higher (start,stop)." << endl;
+    cerr                        << "\t\t- \"b\"     Report distance with respect to B." << endl;
+    cerr                        << "\t\t            When B is on the - strand, \"upstream\" means A has a higher (start,stop)." << endl << endl;
 
     cerr << "\t-no\t"           << "Ignore features in B that overlap A.  That is, we want close, but " << endl;
     cerr                        << "\t\tnot touching features only." << endl << endl;


### PR DESCRIPTION
Hi!

I'm not sure why a signed distance wasn't present before, but it's super important for the kinds of graphs I'm trying to generate with your tools. (Don't tell me this was there before and I just missed it!)

Added a new option -D to closestBed that reports a signed distance from features in A to features in B. One caveat is that the distance depends on the strand of A.  Positive strand A features behave as you might expect, but negative strand A features have upstream features that are actually "to the right" of the features in A.

I'm not sure how my check for A's strandedness fits in with BED3 land-- I'm just testing for a.strand == "+" which could be updated to check for a.strand == "-", since it looks like BED3 files have an empty "" strand.

Thanks for the tools!
