### PR TITLE
include <algorithm> for gcc 4.4.3

### DIFF
--- a/src/utils/genomeFile/genomeFile.cpp
+++ b/src/utils/genomeFile/genomeFile.cpp
@@ -11,6 +11,7 @@
 ******************************************************************************/
 #include "lineFileUtilities.h"
 #include "genomeFile.h"
+#include <algorithm>
 
 
 GenomeFile::GenomeFile(const string &genomeFile) {


### PR DESCRIPTION
compile error under gcc 4.4.3:

"genomeFile.cpp:90: error: ‘lower_bound’ was not declared in this scope"

 . . . just needed to explicitly include <algorithm> in genomeFile.cpp and it compiles no prob.
