### PR TITLE
Regression on -wao?

### DIFF
--- a/src/intersectBed/intersectBed.cpp
+++ b/src/intersectBed/intersectBed.cpp
@@ -60,14 +60,22 @@ bool BedIntersect::processHits(const BED &a, const vector<BED> &hits) {
     // return hitsFound;
     bool hitsFound   = false;
     if (_printable == true) {
-        vector<BED>::const_iterator h       = hits.begin();
-        vector<BED>::const_iterator hitsEnd = hits.end();
-        for (; h != hitsEnd; ++h) {
-            CHRPOS s = max(a.start, h->start);
-            CHRPOS e = min(a.end, h->end);
-            int overlapBases = (e - s);
-            ReportOverlapDetail(overlapBases, a, *h, s, e);
-            hitsFound = true;
+        // -wao the user wants to force the reporting of 0 overlap
+        if (hits.size() == 0 && _writeAllOverlap) {
+            _bedA->reportBedTab(a);
+            _bedB->reportNullBedTab();
+            printf("0\n");
+        }
+        else {
+            vector<BED>::const_iterator h       = hits.begin();
+            vector<BED>::const_iterator hitsEnd = hits.end();
+            for (; h != hitsEnd; ++h) {
+                CHRPOS s = max(a.start, h->start);
+                CHRPOS e = min(a.end, h->end);
+                int overlapBases = (e - s);
+                ReportOverlapDetail(overlapBases, a, *h, s, e);
+                hitsFound = true;
+            }
         }
     }
     else {
@@ -179,12 +187,6 @@ void BedIntersect::ReportOverlapSummary(const BED &a, const int &numOverlapsFoun
     // -v  report iff there were no overlaps
     else if (_noHit && (numOverlapsFound == 0)) {
         _bedA->reportBedNewLine(a);
-    }
-    // -wao the user wants to force the reporting of 0 overlap
-    else if (_writeAllOverlap && (numOverlapsFound == 0)) {
-        _bedA->reportBedTab(a);
-        _bedB->reportNullBedTab();
-        printf("0\n");
     }
 }
 


### PR DESCRIPTION
It seems that `intersectBed -wao` isn't reporting all features in A, as expected according to the docs:

```
        -wao    Write the original A and B entries plus the number of base
                pairs of overlap between the two features.
                - Overlapping features restricted by -f and -r.
                  However, A features w/o overlap are also reported
                  with a NULL B feature and overlap = 0
```

See the following:

```
$ cat a.bed
chr1    1       100     feature1        0       +
chr1    100     200     feature2        0       +
chr1    150     500     feature3        0       -
chr1    900     950     feature4        0       +
$ cat b.bed 
chr1    155     200     feature5        0       -
chr1    800     901     feature6        0       +
$ intersectBed -a a.bed -b b.bed -wao
chr1    100     200     feature2        0       +       chr1    155     200     feature5        0       -       45
chr1    150     500     feature3        0       -       chr1    155     200     feature5        0       -       45
chr1    900     950     feature4        0       +       chr1    800     901     feature6        0       +       1
```

feature1 is missing from the output.  This commit fixes the problem afaict for -wao, including when a fractional or reciprocal overlap is requested (-f and -r).

Regression cause might be that `BedIntersect::ReportOverlapSummary` is no longer called when -wao is requested since _printable on https://github.com/jakebiesinger/bedtools/commit/8f16d7d2958b42faa855b2b33d9c79e9007ea776#L0L62 implies 1 or more lines from B will be reported. -wao is a special case where sometimes B features are reported and sometimes they aren't.
