### PR TITLE
Restructure auto-git-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 SHELL := /bin/bash -e
 
-VERSION_FILE=./src/utils/version/version.h
+VERSION_FILE=./src/utils/version/version_git.h
 
 
 # define our object and binary directories
@@ -55,6 +55,7 @@ SUBDIRS = $(SRC_DIR)/annotateBed \
 		  $(SRC_DIR)/windowMaker
 
 UTIL_SUBDIRS =	$(SRC_DIR)/utils/bedFile \
+				$(SRC_DIR)/utils/version \
 				$(SRC_DIR)/utils/bedGraphFile \
 				$(SRC_DIR)/utils/chromsweep \
 				$(SRC_DIR)/utils/gzstream \
@@ -122,13 +123,12 @@ test: all
 .PHONY: gitversion
 gitversion:
 	@( BEDTOOLS_VERSION="" ; \
-	[ -e "$(VERSION_FILE)" ] && BEDTOOLS_VERSION=$$(grep "define VERSION " "$(VERSION_FILE)" | cut -f3 -d" " | sed 's/"//g') ; \
+	[ -e "$(VERSION_FILE)" ] && BEDTOOLS_VERSION=$$(grep "define VERSION_GIT " "$(VERSION_FILE)" | cut -f3 -d" " | sed 's/"//g') ; \
 	GIT_VERSION=$$(git describe --always --tags --dirty) ; \
 	echo "BEDTOOLS_VERSION = $$BEDTOOLS_VERSION" ; \
 	echo "GIT_VERSION = $$GIT_VERSION" ; \
 	if [ "$${GIT_VERSION}" != "$${BEDTOOLS_VERSION}" ] ; then \
 		mkdir -p ./src/utils/version ; \
 		echo "Updating version file." ; \
-		printf "#ifndef VERSION_H\n#define VERSION_H\n\n#define VERSION \"$${GIT_VERSION}\"\n\n#endif /* VERSION_H */\n" > $(VERSION_FILE) ; \
-		$(MAKE) clean; \
+		printf "#ifndef VERSION_GIT_H\n#define VERSION_GIT_H\n\n#define VERSION_GIT \"$${GIT_VERSION}\"\n\n#endif /* VERSION_GIT_H */\n" > $(VERSION_FILE) ; \
 	fi )

--- a/src/utils/version/Makefile
+++ b/src/utils/version/Makefile
@@ -1,0 +1,27 @@
+OBJ_DIR = ../../../obj/
+BIN_DIR = ../../../bin/
+UTILITIES_DIR = ../../utils/
+# -------------------
+# define our includes
+# -------------------
+INCLUDES = 
+
+# ----------------------------------
+# define our source and object files
+# ----------------------------------
+SOURCES= version.cpp
+HEADERS= version.h version_git.h
+OBJECTS= $(SOURCES:.cpp=.o)
+BUILT_OBJECTS= $(patsubst %,$(OBJ_DIR)/%,$(OBJECTS))
+
+all: $(BUILT_OBJECTS)
+
+.PHONY: all
+
+$(BUILT_OBJECTS): $(SOURCES) $(HEADERS)
+	@echo "  * compiling" $(*F).cpp
+	@$(CXX) -c -o $@ $(*F).cpp $(LDFLAGS) $(CXXFLAGS)
+
+clean:
+	@echo "Cleaning up."
+	@rm -f $(OBJ_DIR)/* $(BIN_DIR)/*

--- a/src/utils/version/version.cpp
+++ b/src/utils/version/version.cpp
@@ -1,0 +1,4 @@
+#include "version.h"
+#include "version_git.h"
+
+const char VERSION[] = VERSION_GIT;

--- a/src/utils/version/version.h
+++ b/src/utils/version/version.h
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+extern const char VERSION[];
+
+#endif /* VERSION_H */


### PR DESCRIPTION
As discussed, with this change, only "version.o" gets recompiled when the git version changes,
and after that, "bedtools.cpp" is recompiled and re-linked.
Ideally, there's not even a need to recompile "bedtools.cpp" (just re-link it), but that's not the way the current makefile is built.

Technically:
VERSION is changed from a #define'd constant to an "extern char VERSION[]" - so all the sub-programs just point to the variable instead of embedding the constant - and are not re-compiled when the version changes.

-gordon
