### PR TITLE
WindowMaker: bugfix with using "srcwinnum" + genome

### DIFF
--- a/src/windowMaker/windowMaker.cpp
+++ b/src/windowMaker/windowMaker.cpp
@@ -51,7 +51,7 @@ void WindowMaker::MakeWindowsFromGenome(const string& genomeFileName) {
     for (size_t c = 0; c < chromList.size(); ++c) {
         string chrom = chromList[c];
 
-        BED bed(chrom,0,_genome->getChromSize(chrom));
+        BED bed(chrom,0,_genome->getChromSize(chrom),chrom,"","");
         MakeBEDWindow(bed);
     }
 }


### PR DESCRIPTION
Hi Aaron,

A tiny bugfix for "makewindows" with my code to generate unique identifiers for the windows.

Current version:

$ bedtools makewindows -g dm3 -w 100000 -i srcwinnum 
chr2L   0   100000  _1
chr2L   100000  200000  _2
chr2L   200000  300000  _3
chr2L   300000  400000  _4
chr2L   400000  500000  _5
...

With the bugfix:
$ bedtools makewindows -g dm3 -w 100000 -i srcwinnum 
chr2L   0   100000  chr2L_1
chr2L   100000  200000  chr2L_2
chr2L   200000  300000  chr2L_3
chr2L   300000  400000  chr2L_4
chr2L   400000  500000  chr2L_5
...

Thanks,
 -gordon
