### PR TITLE
BamToBed: properly fail on non-existing input files.

### DIFF
--- a/src/bamToBed/bamToBed.cpp
+++ b/src/bamToBed/bamToBed.cpp
@@ -229,7 +229,10 @@ void ConvertBamToBed(const string &bamFile, bool useEditDistance, const string &
                      bool useCigar,   bool useNovoalign, bool useBWA) {
     // open the BAM file
     BamReader reader;
-    reader.Open(bamFile);
+    if (!reader.Open(bamFile)) {
+        cerr << "Failed to open BAM file " << bamFile << endl;
+        exit(1);
+    }
 
     // get header & reference information
     string header = reader.GetHeaderText();
@@ -257,7 +260,10 @@ void ConvertBamToBed(const string &bamFile, bool useEditDistance, const string &
 void ConvertBamToBedpe(const string &bamFile, const bool &useEditDistance) {
     // open the BAM file
     BamReader reader;
-    reader.Open(bamFile);
+    if (!reader.Open(bamFile)) {
+        cerr << "Failed to open BAM file " << bamFile << endl;
+        exit(1);
+    }
 
     // get header & reference information
     string header = reader.GetHeaderText();


### PR DESCRIPTION
Hi Aaron,

currently, BamToBed succeeds (exit code 0) if the input file doesn't exist (spent an hour debugging a pipeline script until a realized it's such a simple thing...)

This patch adds proper error message and exit code.
# Before:

$ bedtools bamtobed -i non_existing_file.bam && echo ok
# ok
# After

$  bedtools bamtobed -i non_existing_file.bam && echo ok
# Failed to open BAM file non_existing_file.bam
