### PR TITLE
let groupby handle a header line (starting with "#") as do other

### DIFF
--- a/src/groupBy/groupBy.cpp
+++ b/src/groupBy/groupBy.cpp
@@ -323,7 +323,7 @@ void GroupBy (const string &inFile,
     TabFile *_tab = new TabFile(inFile);
     _tab->Open();
     while ((tabLineStatus = _tab->GetNextTabLine(inFields, lineNum)) != TAB_INVALID) {
-        if (tabLineStatus == TAB_VALID) {
+        if ((tabLineStatus == TAB_VALID) || (tabLineStatus == TAB_HEADER)) {
 
             if (first_line) {
                 first_line = false;

--- a/test/groupBy/test-groupby.sh
+++ b/test/groupBy/test-groupby.sh
@@ -5,10 +5,24 @@ lines_d=$(../../bin/groupBy -g 1-2,3 -o collapse -c 4 -i ../map/values3.bed | wc
 
 check(){
     if [ "$1" != "$2" ]; then
-        "fail groupby"
+        echo "fail groupby" $1 $2
     fi
 }
 
 check $lines_a $lines_b
 check $lines_a $lines_c
 check $lines_a $lines_d
+
+
+H=$(head -n 1 values3.header.bed)
+A=$(../../bin/bedtools groupby -i values3.header.bed -g 1,2,3 -c 4 -o concat -inheader | head -n 1)
+
+if [ "$A" != $'chr1\t0\t10\ta1' ]; then
+        echo "fail groupby"
+fi
+
+B=$(../../bin/bedtools groupby -i values3.header.bed -g 1,2,3 -c 4 -o concat -header | head -n 1)
+
+if [ "$B" != $'#chrom\tstart\tend\tconcat(A)' ]; then
+        echo "fail groupby"
+fi

--- a/test/groupBy/values3.header.bed
+++ b/test/groupBy/values3.header.bed
@@ -1,0 +1,13 @@
+#chrom	start	end	A	B	C
+chr1	0	10	a1	10	+
+chr1	10	20	a2	5	+
+chr1	11	21	a3	5	+
+chr1	20	30	a4	15	+
+chr1	20	30	a5	15	+
+chr1	20	30	a6	15	+
+chr1	120	130	a7	1	+
+chr3	0	10	a8	1	+
+chr3	10	20	a9	2	+
+chr3	20	30	a10	3	+
+chr3	120	130	a11	4	+
+chr3	120	130	a12	4	+


### PR DESCRIPTION
bedtools subcommands.
