### PR TITLE
Allow overriding BT to test bedtools from other paths.

### DIFF
--- a/test/bamtobed/test-bamtobed.sh
+++ b/test/bamtobed/test-bamtobed.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/bed12tobed6/test-bed12tobed6.sh
+++ b/test/bed12tobed6/test-bed12tobed6.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/closest/test-closest.sh
+++ b/test/closest/test-closest.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/cluster/test-cluster.sh
+++ b/test/cluster/test-cluster.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/coverage/test-coverage.sh
+++ b/test/coverage/test-coverage.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/expand/test-expand.sh
+++ b/test/expand/test-expand.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/flank/test-flank.sh
+++ b/test/flank/test-flank.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/general/test-general.sh
+++ b/test/general/test-general.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/genomecov/test-genomecov.sh
+++ b/test/genomecov/test-genomecov.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/getfasta/test-getfasta.sh
+++ b/test/getfasta/test-getfasta.sh
@@ -6,7 +6,7 @@
 # aggggggggg
 # cggggggggg
 
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/groupBy/test-groupby.sh
+++ b/test/groupBy/test-groupby.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 lines_a=$($BT groupby -g 3-1 -o collapse -c 4 -i ../map/values3.bed | wc -l)
 lines_b=$($BT groupby -g 1-3 -o collapse -c 4 -i ../map/values3.bed | wc -l)

--- a/test/intersect/test-intersect.sh
+++ b/test/intersect/test-intersect.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/jaccard/test-jaccard.sh
+++ b/test/jaccard/test-jaccard.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/map/test-map.sh
+++ b/test/map/test-map.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/merge/test-merge.sh
+++ b/test/merge/test-merge.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/multicov/test-multicov.sh
+++ b/test/multicov/test-multicov.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/slop/test-slop.sh
+++ b/test/slop/test-slop.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {

--- a/test/subtract/test-subtract.sh
+++ b/test/subtract/test-subtract.sh
@@ -1,4 +1,4 @@
-BT=../../bin/bedtools
+BT=${BT-../../bin/bedtools}
 
 check()
 {


### PR DESCRIPTION
Hello Aaron (again),

thanks for the 2.17.0 release.  It is on its way to the Debian archive.

I am distributing the regression tests in the package, but in order to test bedtools after it is installed in /usr/bin, it is needed to override the BT variable in the shell scripts of the test suite.

The two commits in this pull request achieves it in compliance with POSIX (tested with dash).

Cheers,
## 

Charles
