### PR TITLE
Fix for tagBam -names segfault

### DIFF
--- a/src/tagBam/tagBam.cpp
+++ b/src/tagBam/tagBam.cpp
@@ -123,7 +123,7 @@ void TagBam::Tag() {
                 else if (_useNames && !_useScores && !_useIntervals) {
                     anno->allHits(a.chrom, a.start, a.end, a.strand, 
                                   hits, _sameStrand, _diffStrand, 0.0, false);
-                    for (size_t j = 0; j < hits.size(); ++i) {
+                    for (size_t j = 0; j < hits.size(); ++j) {
                         annotations << hits[j].name;
                         if (j < hits.size() - 1) annotations << ",";
                     }


### PR DESCRIPTION
Fixed a segfault in tagBam -names. It was caused by a small typo.
