### PR TITLE
add n_intersections to jaccard output

### DIFF
--- a/src/jaccard/jaccard.cpp
+++ b/src/jaccard/jaccard.cpp
@@ -53,7 +53,7 @@ Jaccard::~Jaccard(void) {
 }
 
 
-unsigned long Jaccard::GetIntersection() {
+unsigned long Jaccard::GetIntersection(size_t &n_intersections) {
     
     _bedA = new BedFile(_bedAFile);
     _bedB = new BedFile(_bedBFile);
@@ -70,13 +70,15 @@ unsigned long Jaccard::GetIntersection() {
     hit_set.second.reserve(10000);
     while (sweep.Next(hit_set)) {
         I += GetTotalIntersection(hit_set.first, hit_set.second);
+        n_intersections += hit_set.second.size();
     }
     return I;
 }
 
 void Jaccard::CalculateJaccard() {
 
-    unsigned long I = GetIntersection();
+    size_t n_intersections = 0;
+    unsigned long I = GetIntersection(n_intersections);
     
     unsigned long U = _bedA->getTotalFlattenedLength() + \
                       _bedB->getTotalFlattenedLength();
@@ -84,13 +86,15 @@ void Jaccard::CalculateJaccard() {
     // header
     cout << "intersection\t"
          << "union\t"
-         << "jaccard"
+         << "jaccard\t"
+         << "n_intersections"
          << endl;
     
     // result
     cout << I << "\t" 
          << U - I << "\t"
-         << (float) I / ((float) U - (float) I)
+         << (float) I / ((float) U - (float) I) << "\t"
+         << n_intersections
          << endl;
 }
 

--- a/src/jaccard/jaccard.h
+++ b/src/jaccard/jaccard.h
@@ -57,7 +57,7 @@ private:
     //------------------------------------------------
     // private methods
     //------------------------------------------------
-    unsigned long GetIntersection();
+    unsigned long GetIntersection(size_t &n_intersections);
     unsigned long GetUnion();
     void CalculateJaccard();
 

--- a/test/jaccard/test-jaccard.sh
+++ b/test/jaccard/test-jaccard.sh
@@ -14,8 +14,8 @@ check()
 ###########################################################
 echo "    jaccard.t01...\c"
 echo \
-"intersection	union	jaccard
-110	110	1" > exp
+"intersection	union	jaccard	n_intersections
+110	110	1	2" > exp
 $BT jaccard -a a.bed -b a.bed > obs
 check obs exp
 rm obs exp
@@ -23,16 +23,16 @@ rm obs exp
 
 echo "    jaccard.t02...\c"
 echo \
-"intersection	union	jaccard
-10	140	0.0714286" > exp
+"intersection	union	jaccard	n_intersections
+10	140	0.0714286	1" > exp
 $BT jaccard -a a.bed -b b.bed > obs
 check obs exp
 rm obs exp
 
 echo "    jaccard.t03...\c"
 echo \
-"intersection	union	jaccard
-10	200	0.05" > exp
+"intersection	union	jaccard	n_intersections
+10	200	0.05	1" > exp
 $BT jaccard -a a.bed -b c.bed > obs
 check obs exp
 rm obs exp
@@ -40,8 +40,8 @@ rm obs exp
 
 echo "    jaccard.t04...\c"
 echo \
-"intersection	union	jaccard
-0	210	0" > exp
+"intersection	union	jaccard	n_intersections
+0	210	0	0" > exp
 $BT jaccard -a a.bed -b d.bed > obs
 check obs exp
 rm obs exp
@@ -51,8 +51,8 @@ rm obs exp
 ###########################################################
 echo "    jaccard.t05...\c"
 echo \
-"intersection	union	jaccard
-10	140	0.0714286" > exp
+"intersection	union	jaccard	n_intersections
+10	140	0.0714286	1" > exp
 cat a.bed | $BT jaccard -a - -b b.bed > obs
 check obs exp
 rm obs exp


### PR DESCRIPTION
jaccard is very useful to gauge the amount of overlap. this pull request adds n_intersections to the outputs that shows the number of unique intersections in -a that overlap with -b.

between the bases of overlap (intersection)

the proportion of overlap (jaccard)

and now the number of intersections (n_intersections)

this gives the most commonly used (simple) metrics when comparing 2 datasets.
