### PR TITLE
ENH: shuffle intervals to non-overlapping locations.

### DIFF
--- a/src/shuffleBed/shuffleBed.h
+++ b/src/shuffleBed/shuffleBed.h
@@ -39,7 +39,7 @@ public:
                bool haveInclude, bool sameChrom, 
                float overlapFraction, int seed, 
                bool chooseChrom, bool isBedpe,
-               size_t _maxTries);
+               size_t _maxTries, bool noOverlapping);
 
     // destructor
     ~BedShuffle(void);
@@ -59,6 +59,7 @@ private:
     bool _chooseChrom;
     bool _isBedpe;
     size_t _maxTries;
+    bool _noOverlapping;
 
 
     // The BED file from which to compute coverage.

--- a/src/shuffleBed/shuffleBedMain.cpp
+++ b/src/shuffleBed/shuffleBedMain.cpp
@@ -46,6 +46,7 @@ int shuffle_main(int argc, char* argv[]) {
     bool chooseChrom      = false;
     bool isBedpe          = false;
     size_t maxTries       = 1000;
+    bool noOverlapping    = false;
 
 
     for(int i = 1; i < argc; i++) {
@@ -121,6 +122,9 @@ int shuffle_main(int argc, char* argv[]) {
         else if(PARAMETER_CHECK("-bedpe", 6, parameterLength)) {
             isBedpe = true;
         }
+        else if(PARAMETER_CHECK("-noOverlapping", 14, parameterLength)) {
+            noOverlapping = true;
+        }
         else {
           cerr << endl << "*****ERROR: Unrecognized parameter: " << argv[i] << " *****" << endl << endl;
             showHelp = true;
@@ -139,7 +143,7 @@ int shuffle_main(int argc, char* argv[]) {
                                         haveInclude, sameChrom, 
                                         overlapFraction, seed, 
                                         chooseChrom, isBedpe,
-                                        maxTries);
+                                        maxTries, noOverlapping);
         delete bc;
         return 0;
     }
@@ -194,6 +198,7 @@ void shuffle_help(void) {
     cerr << "\t-maxTries\t"         << "\n\t\tMax. number of attempts to find a home for a shuffled interval" << endl;
     cerr                            << "\t\tin the presence of -incl or -excl." << endl;
     cerr                            << "\t\tDefault = 1000." << endl;
+    cerr << "\t-noOverlapping\t"         << "\n\t\tdont allow shuffled intervals to overlap." << endl;
 
     cerr << "Notes: " << endl;
     cerr << "\t(1)  The genome file should tab delimited and structured as follows:" << endl;

--- a/src/utils/bedFile/bedFile.cpp
+++ b/src/utils/bedFile/bedFile.cpp
@@ -83,6 +83,18 @@ BedFile::BedFile(string &bedFile)
   _total_length(0)
 {}
 
+BedFile::BedFile(void)
+: _isGff(false),
+  _isVcf(false),
+  _typeIsKnown(false),
+  _merged_start(-1),
+  _merged_end(-1),
+  _merged_chrom(""),
+  _prev_start(-1),
+  _prev_chrom(""),
+  _total_length(0)
+{}
+
 // Destructor
 BedFile::~BedFile(void) {
 }
@@ -654,6 +666,11 @@ void BedFile::loadBedFileIntoMap() {
         }
     }
     Close();
+}
+
+void BedFile::addBEDIntoMap(BED bedEntry) {
+    BIN bin = getBin(bedEntry.start, bedEntry.end);
+    bedMap[bedEntry.chrom][bin].push_back(bedEntry);
 }
 
 

--- a/src/utils/bedFile/bedFile.h
+++ b/src/utils/bedFile/bedFile.h
@@ -380,6 +380,7 @@ public:
 
     // Constructor
     BedFile(string &);
+    BedFile(void);
 
     // Destructor
     ~BedFile(void);
@@ -417,6 +418,9 @@ public:
     // load a BED file into a map keyed by chrom, then bin. value is 
     // vector of BEDs
     void loadBedFileIntoMap();
+
+    // load a BED entry into and existing map
+    void addBEDIntoMap(BED bedEntry);
 
     // load a BED file into a map keyed by chrom, then bin. value is 
     // vector of BEDCOVs


### PR DESCRIPTION
This definitely needs some review and some tests but "seems to work". It allows shuffling a set of intervals to non-overlapping locations. This may be a useful constraint, e.g. in cases where we are simulating deletions, loss-of-heterozygosity or copy-number events.

It progressively adds each interval to the _exclude map, so it may become slow (or impossible to place later intervals) when the -i BED file has many / large intervals.
