### PR TITLE
Update merge.rst

### DIFF
--- a/docs/content/tools/merge.rst
+++ b/docs/content/tools/merge.rst
@@ -15,7 +15,7 @@ file into a single feature which spans all of the combined features.
 .. note::
 
     ``bedtools merge`` requires that you presort your data by chromosome and
-    then by start position (e.g., ``sort -k1,1 -k2,2n in.bed > in.sorted.bed``
+    then by start position (e.g., ``sort -k1,1V -k2,2n in.bed > in.sorted.bed``
     for BED files).
     
 .. seealso::


### PR DESCRIPTION
For sort, should chr9 be before chr10?  

I Added a V to the end of the first sort criteria.  V is for version.  In this case V will sort the numeric section of the first field as a number so that chr9 comes before chr10.  If the first field is just for grouping and the order of chr9 vs chr10 does not matter, then this can be left out.
